### PR TITLE
postgresql module now requires postgresql::postgresql_password

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -4,7 +4,7 @@ class gitea::database {
       postgresql::server::db { $gitea::database_name:
         user     => $gitea::database_user,
         owner    => $gitea::database_user,
-        password => postgresql_password($gitea::database_user, $gitea::database_password),
+        password => ::postgresql::postgresql_password($gitea::database_user, $gitea::database_password),
         require  => Class['postgresql::server'],
       }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
get rid of the following error when using recent postgresql module:
```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, deprecation. postgresql_password. This method is deprecated, please use postgresql::postgresql_password instead. at ["/etc/puppetlabs/code/environments/production/modules/gitea/manifests/database.pp", 7]:["/etc/puppetlabs/code/environments/production/modules/gitea/manifests/init.pp", 51] (file: /etc/puppetlabs/code/environments/production/modules/gitea/manifests/database.pp, line: 7, column: 21) on node gitea.example.com
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run

```
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
